### PR TITLE
Add support for Component and Incident endpoints.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1,13 +1,18 @@
 <?php
+
 namespace StatusPage\SDK;
 
 use Guzzle\Http\Client as GuzzleClient;
 use Guzzle\Http\Curl\CurlVersion;
+
 use StatusPage\SDK\Metrics\MetricsEndpoint;
 use StatusPage\SDK\Subscribers\SubscribersEndpoint;
+use StatusPage\SDK\Components\ComponentsEndpoint;
+use StatusPage\SDK\Incidents\IncidentsEndpoint;
 
 class Client
 {
+
     const VERSION = '0.1';
 
     protected $guzzleClient;
@@ -15,14 +20,13 @@ class Client
     public function __construct(GuzzleClient $guzzleClient, $pageId, $token)
     {
         $this->guzzleClient = $guzzleClient;
+
         $this->guzzleClient->setBaseUrl("https://api.statuspage.io/v1/pages/$pageId/");
-        $this->guzzleClient->setDefaultOption('headers', array('Authorization' => 'OAuth '.$token));
-        $this->guzzleClient->setUserAgent(sprintf(
-            'statuspage-sdk-php/%s curl/%s PHP/%s',
-            self::VERSION,
-            CurlVersion::getInstance()->get('version'),
-            PHP_VERSION
+        $this->guzzleClient->setDefaultOption('headers', array(
+            'Authorization' => 'OAuth ' . $token
         ));
+
+        $this->guzzleClient->setUserAgent(sprintf('statuspage-sdk-php/%s curl/%s PHP/%s', self::VERSION, CurlVersion::getInstance()->get('version'), PHP_VERSION));
     }
 
     public function send($endpoint, $method = 'GET', $headers = null, $body = null)
@@ -41,5 +45,15 @@ class Client
     public function subscribers()
     {
         return new SubscribersEndpoint($this);
+    }
+
+    public function components()
+    {
+        return new ComponentsEndpoint($this);
+    }
+
+    public function incidents()
+    {
+        return new IncidentsEndpoint($this);
     }
 }

--- a/src/Components/Component.php
+++ b/src/Components/Component.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace StatusPage\SDK\Components;
+
+class Component
+{
+
+    protected $id;
+
+    protected $name;
+
+    protected $position;
+
+    protected $status;
+
+    protected $created_at;
+
+    protected $updated_at;
+
+    /**
+     *
+     * @param string $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     *
+     * @param string $name
+     */
+    public function setCreatedAt($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getCreatedAt()
+    {
+        return $this->name;
+    }
+
+    /**
+     *
+     * @param int $position
+     */
+    public function setPosition($position)
+    {
+        $this->position = $position;
+    }
+
+    /**
+     *
+     * @return int
+     */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    /**
+     *
+     * @param string $status
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     *
+     * @param string $created_at
+     */
+    public function setCreatedAt($created_at)
+    {
+        $this->created_at = $created_at;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getCreatedAt()
+    {
+        return $this->created_at;
+    }
+
+    /**
+     *
+     * @param string $updated_at
+     */
+    public function setUpdatedAt($updated_at)
+    {
+        $this->updated_at = $updated_at;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updated_at;
+    }
+}

--- a/src/Components/ComponentsEndpoint.php
+++ b/src/Components/ComponentsEndpoint.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace StatusPage\SDK\Components;
+
+use StatusPage\SDK\Endpoint;
+
+class ComponentsEndpoint extends Endpoint
+{
+
+    public function updateComponent($component_id, $status)
+    {
+
+        if (!in_array($status, ['', 'operational', 'degraded_performance', 'partial_outage', 'major_outage'])) {
+            throw new \InvalidArgumentException('$status is not valid.');
+        }
+
+        $data = array(
+            'component' => array(
+                'status' => $status
+            )
+        );
+
+        $result = $this->client->send("components/$component_id.json",'PATCH', null, $data);
+
+        return $result;
+    }
+
+}

--- a/src/Incidents/Incident.php
+++ b/src/Incidents/Incident.php
@@ -1,0 +1,305 @@
+<?php
+namespace StatusPage\SDK\Incidents;
+
+class Incident
+{
+
+    protected $name;
+
+    protected $status;
+
+    protected $created_at;
+
+    protected $updated_at;
+
+    protected $monitoring_at;
+
+    protected $resolved_at;
+
+    protected $impact;
+
+    protected $shortlink;
+
+    protected $postmortem_ignored;
+
+    protected $postmortem_body;
+
+    protected $postmortem_body_last_updated_at;
+
+    protected $postmortem_published_at;
+
+    protected $postmortem_notified_subscribers;
+
+    protected $postmortem_notified_twitter;
+
+    protected $backfilled;
+
+    protected $scheduled_for;
+
+    protected $scheduled_until;
+
+    protected $scheduled_remind_prior;
+
+    protected $scheduled_reminded_at;
+
+    protected $impact_override;
+
+    protected $scheduled_auto_in_progress;
+
+    protected $scheduled_auto_completed;
+
+    protected $id;
+
+    protected $updates = array();
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->created_at;
+    }
+
+    public function setCreatedAt($created_at)
+    {
+        $this->created_at = $created_at;
+    }
+
+    public function getUpdatedAt()
+    {
+        return $this->updated_at;
+    }
+
+    public function setUpdatedAt($updated_at)
+    {
+        $this->updated_at = $updated_at;
+    }
+
+    public function getMonitoringAt()
+    {
+        return $this->monitoring_at;
+    }
+
+    public function setMonitoringAt($monitoring_at)
+    {
+        $this->monitoring_at = $monitoring_at;
+    }
+
+    public function getResolvedAt()
+    {
+        return $this->resolved_at;
+    }
+
+    public function setResolvedAt($resolved_at)
+    {
+        $this->resolved_at = $resolved_at;
+    }
+
+    public function getImpact()
+    {
+        return $this->impact;
+    }
+
+    public function setImpact($impact)
+    {
+        $this->impact = $impact;
+    }
+
+    public function getShortlink()
+    {
+        return $this->shortlink;
+    }
+
+    public function setShortlink($shortlink)
+    {
+        $this->shortlink = $shortlink;
+    }
+
+    public function getPostmortemIgnored()
+    {
+        return $this->postmortem_ignored;
+    }
+
+    public function setPostmortemIgnored($postmortem_ignored)
+    {
+        $this->postmortem_ignored = $postmortem_ignored;
+    }
+
+    public function getPostmortemBody()
+    {
+        return $this->postmortem_body;
+    }
+
+    public function setPostmortemBody($postmortem_body)
+    {
+        $this->postmortem_body = $postmortem_body;
+    }
+
+    public function getPostmortemBodyLastUpdatedAt()
+    {
+        return $this->postmortem_body_last_updated_at;
+    }
+
+    public function setPostmortemBodyLastUpdatedAt($postmortem_body_last_updated_at)
+    {
+        $this->postmortem_body_last_updated_at = $postmortem_body_last_updated_at;
+    }
+
+    public function getPostmortemPublishedAt()
+    {
+        return $this->postmortem_published_at;
+    }
+
+    public function setPostmortemPublishedAt($postmortem_published_at)
+    {
+        $this->postmortem_published_at = $postmortem_published_at;
+    }
+
+    public function getPostmortemNotifiedSubscribers()
+    {
+        return $this->postmortem_notified_subscribers;
+    }
+
+    public function setPostmortemNotifiedSubscribers($postmortem_notified_subscribers)
+    {
+        $this->postmortem_notified_subscribers = $postmortem_notified_subscribers;
+    }
+
+    public function getPostmortemNotifiedTwitter()
+    {
+        return $this->postmortem_notified_twitter;
+    }
+
+    public function setPostmortemNotifiedTwitter($postmortem_notified_twitter)
+    {
+        $this->postmortem_notified_twitter = $postmortem_notified_twitter;
+    }
+
+    public function getBackfilled()
+    {
+        return $this->backfilled;
+    }
+
+    public function setBackfilled($backfilled)
+    {
+        $this->backfilled = $backfilled;
+    }
+
+    public function getScheduledFor()
+    {
+        return $this->scheduled_for;
+    }
+
+    public function setScheduledFor($scheduled_for)
+    {
+        $this->scheduled_for = $scheduled_for;
+    }
+
+    public function getScheduledUntil()
+    {
+        return $this->scheduled_until;
+    }
+
+    public function setScheduledUntil($scheduled_until)
+    {
+        $this->scheduled_until = $scheduled_until;
+    }
+
+    public function getScheduledRemindPrior()
+    {
+        return $this->scheduled_remind_prior;
+    }
+
+    public function setScheduledRemindPrior($scheduled_remind_prior)
+    {
+        $this->scheduled_remind_prior = $scheduled_remind_prior;
+    }
+
+    public function getScheduledRemindedAt()
+    {
+        return $this->scheduled_reminded_at;
+    }
+
+    public function setScheduledRemindedAt($scheduled_reminded_at)
+    {
+        $this->scheduled_reminded_at = $scheduled_reminded_at;
+    }
+
+    public function getImpactOverride()
+    {
+        return $this->impact_override;
+    }
+
+    public function setImpactOverride($impact_override)
+    {
+        $this->impact_override = $impact_override;
+    }
+
+    public function getScheduledAutoInProgress()
+    {
+        return $this->scheduled_auto_in_progress;
+    }
+
+    public function setScheduledAutoInProgress($scheduled_auto_in_progress)
+    {
+        $this->scheduled_auto_in_progress = $scheduled_auto_in_progress;
+    }
+
+    public function getScheduledAutoCompleted()
+    {
+        return $this->scheduled_auto_completed;
+    }
+
+    public function setScheduledAutoCompleted($scheduled_auto_completed)
+    {
+        $this->scheduled_auto_completed = $scheduled_auto_completed;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getUpdates()
+    {
+        return $this->updates;
+    }
+
+    public function addUpdate($id, $body, $created_at, $display_at, $status, $twitter_updated_at, $updated_at, $wants_twitter_update)
+    {
+        $update = new Update();
+
+        $update->setID($id);
+        $update->setBody($body);
+        $update->setCreatedAt($created_at);
+        $update->setDisplayAt($display_at);
+        $update->setStatus($status);
+        $update->setTwitterUpdatedAt($twitter_updated_at);
+        $update->setUpdatedAt($updated_at);
+        $update->setWantsTwitterUpdate($wants_twitter_update);
+
+        $this->updates[] = $update;
+    }
+}

--- a/src/Incidents/IncidentsEndpoint.php
+++ b/src/Incidents/IncidentsEndpoint.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace StatusPage\SDK\Incidents;
+
+use StatusPage\SDK\Endpoint;
+
+class IncidentsEndpoint extends Endpoint
+{
+
+    public function unresolved()
+    {
+        $results = $this->client->send('incidents/unresolved.json', 'GET');
+
+        $incidents = array();
+
+        foreach($results as $result) {
+
+            $incident = new Incident();
+
+            $incident->setName($result['name']);
+            $incident->setStatus($result['status']);
+            $incident->setCreatedAt($result['created_at']);
+            $incident->setUpdatedAt($result['updated_at']);
+            $incident->setMonitoringAt($result['monitoring_at']);
+            $incident->setResolvedAt($result['resolved_at']);
+            $incident->setImpact($result['impact']);
+            $incident->setShortLink($result['shortlink']);
+            $incident->setPostmortemIgnored($result['postmortem_ignored']);
+            $incident->setPostmortemBody($result['postmortem_body']);
+            $incident->setPostmortemBodyLastUpdatedAt($result['postmortem_body_last_updated_at']);
+            $incident->setPostmortemPublishedAt($result['postmortem_published_at']);
+            $incident->setPostmortemNotifiedSubscribers($result['postmortem_notified_subscribers']);
+            $incident->setPostmortemNotifiedTwitter($result['postmortem_notified_twitter']);
+            $incident->setBackfilled($result['backfilled']);
+            $incident->setScheduledFor($result['scheduled_for']);
+            $incident->setScheduledUntil($result['scheduled_until']);
+            $incident->setScheduledRemindPrior($result['scheduled_remind_prior']);
+            $incident->setScheduledRemindedAt($result['scheduled_reminded_at']);
+            $incident->setImpactOverride($result['impact_override']);
+            $incident->setScheduledAutoInProgress($result['scheduled_auto_in_progress']);
+            $incident->setScheduledAutoCompleted($result['scheduled_auto_completed']);
+            $incident->setId($result['id']);
+
+            foreach($result['incident_updates'] as $result_update) {
+
+                $incident->addUpdate(
+                    $result_update['id'],
+                    $result_update['body'],
+                    $result_update['created_at'],
+                    $result_update['display_at'],
+                    $result_update['status'],
+                    $result_update['twitter_updated_at'],
+                    $result_update['updated_at'],
+                    $result_update['wants_twitter_update']
+                );
+            }
+
+            $incidents[] = $incident;
+        }
+
+        return $incidents;
+    }
+
+    public function createRealtime($name, $status, $message, $wants_twitter_update, $impact_override, $component_ids)
+    {
+
+        $data = array(
+            'incident' => array(
+                'name' => $name,
+                'status' => $status,
+                'message' => $message,
+                'wants_twitter_update'=> $wants_twitter_update,
+                'impact_override' => $impact_override,
+                'component_ids' => $component_ids
+            )
+        );
+
+        $result = $this->client->send("incidents.json", 'POST', null, $data);
+
+        return $result;
+    }
+
+}

--- a/src/Incidents/Update.php
+++ b/src/Incidents/Update.php
@@ -1,0 +1,102 @@
+<?php
+namespace StatusPage\SDK\Incidents;
+
+class Update
+{
+
+    protected $id;
+
+    protected $body;
+
+    protected $created_at;
+
+    protected $display_at;
+
+    protected $status;
+
+    protected $twitter_updated_at;
+
+    protected $updated_at;
+
+    protected $wants_twitter_update;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->created_at;
+    }
+
+    public function setCreatedAt($created_at)
+    {
+        $this->created_at = $created_at;
+    }
+
+    public function getDisplayAt()
+    {
+        return $this->display_at;
+    }
+
+    public function setDisplayAt($display_at)
+    {
+        $this->display_at = $display_at;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    public function getTwitterUpdatedAt()
+    {
+        return $this->twitter_updated_at;
+    }
+
+    public function setTwitterUpdatedAt($twitter_updated_at)
+    {
+        $this->twitter_updated_at = $twitter_updated_at;
+    }
+
+    public function getUpdatedAt()
+    {
+        return $this->updated_at;
+    }
+
+    public function setUpdatedAt($updated_at)
+    {
+        $this->updated_at = $updated_at;
+    }
+
+    public function getWantsTwitterUpdate()
+    {
+        return $this->wants_twitter_update;
+    }
+
+    public function setWantsTwitterUpdate($wants_twitter_update)
+    {
+        $this->wants_twitter_update = $wants_twitter_update;
+    }
+}


### PR DESCRIPTION
This code adds basic support for updating individual Component statuses within StatusPage.io as well as creating real-time incidents. Fetching unresolved incidents is also supported with this change and initial work on the required data structures has also been introduced.